### PR TITLE
set proto correct if running as tcp-client

### DIFF
--- a/templates/server.erb
+++ b/templates/server.erb
@@ -56,7 +56,7 @@ crl-verify <%= @server_directory %>/<%= @ca_name %>/crl.pem
 <% unless @remote -%>
 proto <%= @proto %>-server
 <% else -%>
-proto <%= @proto %>
+proto <%= @proto %>-client
 <% end -%>
 <% else -%>
 proto <%= @proto %>


### PR DESCRIPTION
See documentation for proto:
–proto p
Use protocol p for communicating with remote host. p can be udp, tcp-client, or tcp-server.The default protocol is udp when –proto is not specified.

This might be wron implemented as there is also a proto field for the
remote argument:
–remote host [port] [proto]
Remote host name or IP address. On the client, multiple –remote options may be specified for redundancy, each referring to a different OpenVPN server. Specifying multiple –remote options for this purpose is a special case of the more general connection-profile feature. See the <connection> documentation below.The OpenVPN client will try to connect to a server at host:port in the order specified by the list of –remote options.
proto indicates the protocol to use when connecting with the remote, and may be “tcp” or “udp”.

For forcing IPv4 or IPv6 connection suffix tcp or udp with 4/6 like udp4/udp6/tcp4/tcp6.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
